### PR TITLE
feat: Add a new trait to help with testing with feature flags

### DIFF
--- a/src/Providers/LaunchDarkly/LaunchDarklyProvider.php
+++ b/src/Providers/LaunchDarkly/LaunchDarklyProvider.php
@@ -24,6 +24,8 @@ class LaunchDarklyProvider implements FeatureFlagsProvider
     {
         /** @var array<string,mixed> */
         $config = Config::get('feature-flags.providers.launchdarkly.options', []);
+
+        /** @var array<string,mixed> */
         $options = array_merge([
             'event_publisher' => Guzzle::eventPublisher()
         ], $config);
@@ -32,6 +34,7 @@ class LaunchDarklyProvider implements FeatureFlagsProvider
         $key = Config::get('feature-flags.providers.launchdarkly.key');
 
         if ($key) {
+            /**  @phpstan-ignore-next-line  */
             $this->client = new LDClient($key, $options);
         }
     }

--- a/src/Traits/InteractsWithFeatureFlags.php
+++ b/src/Traits/InteractsWithFeatureFlags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\FeatureFlags\Traits;
+
+trait InteractsWithFeatureFlags
+{
+    public function switchFeatureFlag(string $key, bool $onOff): void
+    {
+        $this->app['config']->set('feature-flags.overrides.'.$key, $onOff);
+    }
+
+    public function enableFeatureFlag(string $key): void
+    {
+
+        $this->switchFeatureFlag($key, true);
+    }
+
+    public function disableFeatureFlag(string $key): void
+    {
+
+        $this->switchFeatureFlag($key, false);
+    }
+}


### PR DESCRIPTION
## Description

Introduce a new InteractsWithFeatureFlags trait to help with testing when feature flags are involved

## Usage
```PHP
// pest

namespace Worksome\FeatureFlags\Traits\InteractsWithFeatureFlags;

uses(InteractsWithFeatureFlags::class);

it('does a test with switching feature flag on and off', function(bool $featureFlagOnOff){
    $this->switchFeatureFlag('feature-1', $featureFlagOnOff);
   
    // Test stuff
})
  ->with([true, false]);
  

it('does a test with enabling feature flag', function(){
   $this->enableFeatureFlag('feature-1');
   
   // Test stuff
});

it('does a test with disabling feature flag', function(){
   $this->disableFeatureFlag('feature-1');
   
   // Test stuff
});
```
